### PR TITLE
Add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "orykami/laravel-ovh-sms",
   "description": "OVH SMS API integration for Laravel 7+.",
-  "keywords": ["laravel", "laravel7", "laravel8", "laravel9", "ovh", "sms", "api"],
+  "keywords": ["laravel", "laravel7", "laravel8", "laravel9", "laravel10", "laravel11", "laravel12", "laravel13", "ovh", "sms", "api"],
   "license": "MIT",
   "authors": [
     {
@@ -11,8 +11,8 @@
   ],
   "require": {
     "php": "^7.4|^8.0|^8.1|^8.2|^8.3",
-    "illuminate/notifications": "^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
-    "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0",
+    "illuminate/notifications": "^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+    "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
     "ovh/ovh": "^v3.0.0"
   },
   "autoload": {


### PR DESCRIPTION
## Summary
- Add Laravel 13 to `illuminate/notifications` and `illuminate/support` version constraints
- Add `laravel13` to keywords (also backfills missing `laravel10`/`laravel11`/`laravel12`)

## Test plan
- [ ] `composer validate`
- [ ] Install in a Laravel 13 project and verify SMS notification channel resolves